### PR TITLE
Add class without license header

### DIFF
--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -25,7 +25,10 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Apply patch
-        run: git apply git-diff.patch
+        run: |
+          ls -lah
+          pwd
+          git apply git-diff.patch
 
       - uses: googleapis/code-suggester@v2
         with:

--- a/src/main/java/com/github/timtebeek/codesuggesteractionreproducer/Foo.java
+++ b/src/main/java/com/github/timtebeek/codesuggesteractionreproducer/Foo.java
@@ -1,0 +1,4 @@
+package com.github.timtebeek.codesuggesteractionreproducer;
+
+public class Foo {
+}

--- a/src/main/java/com/github/timtebeek/codesuggesteractionreproducer/Foo.java
+++ b/src/main/java/com/github/timtebeek/codesuggesteractionreproducer/Foo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.timtebeek.codesuggesteractionreproducer;
 
 public class Foo {


### PR DESCRIPTION
Workflow still needs changes after reading: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
- [ ] Likely do not use `pull_request_target` directly as that has write access
- [ ] But instead use `pull_request` and archive the `.patch` file
- [ ] Then in a separate followup workflow only run https://github.com/googleapis/code-suggester to create the code suggestions, with minimally scoped permissions
